### PR TITLE
Fix: Break nested forloop when put_item success in pack_to_bin function

### DIFF
--- a/py3dbp/main.py
+++ b/py3dbp/main.py
@@ -162,6 +162,8 @@ class Packer:
                 if bin.put_item(item, pivot):
                     fitted = True
                     break
+            if fitted:
+                break
 
         if not fitted:
             bin.unfitted_items.append(item)


### PR DESCRIPTION
Before:
FITTED ITEMS:
====>  684796_1(74x228x130, weight: 1) pos([0, 0, 0]) rt(0) vol(2193360)
====>  684796_2(74x228x130, weight: 1) pos([74, 0, 0]) rt(5) vol(2193360)
====>  546663_1(88x87x120, weight: 1) pos([148, 0, 0]) rt(5) vol(918720)
====>  546663_2(88x87x120, weight: 1) pos([236, 0, 0]) rt(5) vol(918720)
![Screen Shot 2020-04-23 at 8 04 46 PM](https://user-images.githubusercontent.com/12237944/80119437-4a975900-85bc-11ea-8047-8615586945fd.png)
After:
FITTED ITEMS:
====>  684796_1(74x228x130, weight: 1) pos([0, 0, 0]) rt(0) vol(2193360)
====>  684796_2(74x228x130, weight: 1) pos([74, 0, 0]) rt(0) vol(2193360)
====>  546663_1(88x87x120, weight: 1) pos([148, 0, 0]) rt(0) vol(918720)
====>  546663_2(88x87x120, weight: 1) pos([236, 0, 0]) rt(0) vol(918720)
![Screen Shot 2020-04-23 at 11 41 53 PM](https://user-images.githubusercontent.com/12237944/80119554-6f8bcc00-85bc-11ea-803c-06f05a14d245.png)


I really appreciate your implementation for this great 3DBinPacking Package(pun intended!)

But I want to verify the result of the algorithm is correct

So I use open3d to visualize the result

As you can see in the first picture

The second item(from left)'s rotation is wrong and it exceeded the bin

After modify the code, it now arrange correctly!  
