### PR TITLE
Request to change "bigger_first=False" with "bigger_bin_first=False" and "bigger_item_first=False"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ packer = Packer()           # PACKER DEFINITION
 packer.add_bin(my_bin)      # ADDING BINS TO PACKER
 packer.add_item(my_item)    # ADDING ITEMS TO PACKER
 
-packer.pack()               # PACKING - by default (bigger_first=False, distribute_items=False, number_of_decimals=3)
+packer.pack()               # PACKING - by default (bigger_bin_first=False, bigger_item_first=False, distribute_items=False, number_of_decimals=3)
 ```
 
 After packing:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Features
 1. Sorting Bins and Items:
-    ```[bigger_first=False/True]``` By default all the bins and items are sorted from the smallest to the biggest, also it can be vice versa, to make the packing in such ordering.
+    ```[bigger_bin_first=False/True]``` and ```[bigger_item_first=False/True]``` By default all the bins and items are sorted from the smallest to the biggest, also it can be vice versa, to make the packing in such ordering.
 2. Item Distribution:
     - ```[distribute_items=True]``` From a list of bins and items, put the items in the bins that at least one item be in one bin that can be fitted. That is, distribute all the items in all the bins so that they can be contained.
     - ```[distribute_items=False]``` From a list of bins and items, try to put all the items in each bin and in the end it show per bin all the items that was fitted and the items that was not.

--- a/py3dbp/main.py
+++ b/py3dbp/main.py
@@ -54,13 +54,13 @@ class Item:
 
 
 class Bin:
-    def __init__(self, name, width, height, depth, max_weight, empty_weight=0):
+    def __init__(self, name, width, height, depth, max_weight, empty_bin_weight=0):
         self.name = name
         self.width = width
         self.height = height
         self.depth = depth
-        self.weight = empty_weight
-        self.empty_weight = empty_weight
+        self.weight = empty_bin_weight
+        self.empty_bin_weight = empty_bin_weight
         self.max_weight = max_weight
         self.items = []
         self.unfitted_items = []
@@ -75,7 +75,7 @@ class Bin:
         self.depth = set_to_decimal(self.depth, number_of_decimals)
         self.max_weight = set_to_decimal(self.max_weight, number_of_decimals)
         self.weight = set_to_decimal(self.weight, number_of_decimals)
-        self.empty_weight = set_to_decimal(self.empty_weight, number_of_decimals)
+        self.empty_bin_weight = set_to_decimal(self.empty_bin_weight, number_of_decimals)
         self.number_of_decimals = number_of_decimals
 
     def string(self):
@@ -125,7 +125,7 @@ class Bin:
                     return fit
 
                 self.items.append(item)
-                self.weight = self.get_total_weight() + self.empty_weight
+                self.weight = self.get_total_weight() + self.empty_bin_weight
 
             if not fit:
                 item.position = valid_item_position

--- a/py3dbp/main.py
+++ b/py3dbp/main.py
@@ -191,8 +191,8 @@ class Packer:
             bin.unfitted_items.append(item)
 
     def pack(
-        self, bigger_first=False, distribute_items=False,
-        number_of_decimals=DEFAULT_NUMBER_OF_DECIMALS
+        self, bigger_bin_first=False, bigger_item_first=False,
+        distribute_items=False, number_of_decimals=DEFAULT_NUMBER_OF_DECIMALS
     ):
         for bin in self.bins:
             bin.format_numbers(number_of_decimals)
@@ -201,10 +201,10 @@ class Packer:
             item.format_numbers(number_of_decimals)
 
         self.bins.sort(
-            key=lambda bin: bin.get_volume(), reverse=bigger_first
+            key=lambda bin: bin.get_volume(), reverse=bigger_bin_first
         )
         self.items.sort(
-            key=lambda item: item.get_volume(), reverse=bigger_first
+            key=lambda item: item.get_volume(), reverse=bigger_item_first
         )
 
         for bin in self.bins:

--- a/py3dbp/main.py
+++ b/py3dbp/main.py
@@ -54,27 +54,34 @@ class Item:
 
 
 class Bin:
-    def __init__(self, name, width, height, depth, max_weight):
+    def __init__(self, name, width, height, depth, max_weight, empty_weight=0):
         self.name = name
         self.width = width
         self.height = height
         self.depth = depth
+        self.weight = empty_weight
+        self.empty_weight = empty_weight
         self.max_weight = max_weight
         self.items = []
         self.unfitted_items = []
         self.number_of_decimals = DEFAULT_NUMBER_OF_DECIMALS
+
+        self.format_numbers(self.number_of_decimals)
+
 
     def format_numbers(self, number_of_decimals):
         self.width = set_to_decimal(self.width, number_of_decimals)
         self.height = set_to_decimal(self.height, number_of_decimals)
         self.depth = set_to_decimal(self.depth, number_of_decimals)
         self.max_weight = set_to_decimal(self.max_weight, number_of_decimals)
+        self.weight = set_to_decimal(self.weight, number_of_decimals)
+        self.empty_weight = set_to_decimal(self.empty_weight, number_of_decimals)
         self.number_of_decimals = number_of_decimals
 
     def string(self):
-        return "%s(%sx%sx%s, max_weight:%s) vol(%s)" % (
-            self.name, self.width, self.height, self.depth, self.max_weight,
-            self.get_volume()
+        return "%s(%sx%sx%s, total_weight:%s, max_weight:%s) vol(%s)" % (
+            self.name, self.width, self.height, self.depth, self.weight, 
+            self.max_weight, self.get_volume()
         )
 
     def get_volume(self):
@@ -118,6 +125,7 @@ class Bin:
                     return fit
 
                 self.items.append(item)
+                self.weight = self.get_total_weight() + self.empty_weight
 
             if not fit:
                 item.position = valid_item_position


### PR DESCRIPTION
Hello,

I would like to propose to add the functionality to sort by bigger bin first and by bigger item first separately. This enhances the algorithm efficiency when trying to determine the number of bins necessary to pack all items.

See [py3dbp_test-example.zip](https://github.com/enzoruiz/3dbinpacking/files/5887349/py3dbp_test-example.zip).

By starting to fit the largest item in the smallest box first, I'm able to pack all my items in **one large box less**!

[LinkedIn](https://www.linkedin.com/in/jonathanrhau/)
[Twitter](https://twitter.com/JonathanRhau)

Best regards,
Jonathan Rhau